### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Creating the nsq river is as simple as (all configuration parameters are provide
             "channel" : "elasticsearch",
             "max_inflight" : 10,
             "max_retries" : 5,
-            "requeue_deplay" : 5,
+            "requeue_delay" : 5,
         },
         "index" : {
             "workers" : 10,


### PR DESCRIPTION
Sample document has `requeue_deplay` instead of `requeue_delay`
